### PR TITLE
Add rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,62 @@
+Documentation:
+  Enabled: false
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - spec/**/*
+
+Metrics/AbcSize:
+  # The ABC size is a calculated magnitude, so this number can be an Integer or
+  # a Float.
+  Max: 15
+
+Metrics/BlockLength:
+  CountComments: false  # count full line comments?
+  Max: 25
+
+Metrics/BlockNesting:
+  Max: 4
+
+Metrics/ClassLength:
+  CountComments: false  # count full line comments?
+  Max: 200
+
+# Avoid complex methods.
+Metrics/CyclomaticComplexity:
+  Max: 6
+
+Metrics/MethodLength:
+  CountComments: false  # count full line comments?
+  Max: 24
+
+Metrics/ModuleLength:
+  CountComments: false  # count full line comments?
+  Max: 200
+
+Metrics/LineLength:
+  Max: 100
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # containing a URI to be longer than Max.
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+  Exclude:
+    - spec/dummy/**/*
+
+Metrics/ParameterLists:
+  Max: 5
+  CountKeywordArgs: true
+
+Metrics/PerceivedComplexity:
+  Max: 12
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/ModuleFunction:
+  Enabled: false
+
+Style/MixinUsage:
+  Exclude:
+    - spec/dummy/bin/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (9.0.0)
+    ast (2.4.0)
     builder (3.2.3)
     capybara (3.9.0)
       addressable
@@ -107,6 +108,7 @@ GEM
       has_scope (~> 0.6)
       railties (>= 4.2, < 5.3)
       responders
+    jaro_winkler (1.5.1)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -138,6 +140,10 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
+    parallel (1.12.1)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
     public_suffix (3.0.3)
     rack (2.0.5)
     rack-test (1.1.0)
@@ -166,6 +172,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.1)
     ransack (2.0.1)
       actionpack (>= 5.0)
@@ -195,6 +202,15 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rubocop (0.59.2)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.10.0)
     sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -212,6 +228,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.4.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -226,6 +243,7 @@ DEPENDENCIES
   capybara
   factory_bot_rails
   rspec-rails (~> 3.8)
+  rubocop (~> 0.59.2)
   sqlite3
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-APP_RAKEFILE = File.expand_path("spec/dummy/Rakefile", __dir__)
+APP_RAKEFILE = File.expand_path('spec/dummy/Rakefile', __dir__)
 load 'rails/tasks/engine.rake'
 
 load 'rails/tasks/statistics.rake'

--- a/active_admin_chat.gemspec
+++ b/active_admin_chat.gemspec
@@ -1,26 +1,27 @@
-$:.push File.expand_path("lib", __dir__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 # Maintain your gem's version:
-require "active_admin_chat/version"
+require 'active_admin_chat/version'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name        = "active_admin_chat"
+  s.name        = 'active_admin_chat'
   s.version     = ActiveAdminChat::VERSION
-  s.authors     = ["Santiago Bartesaghi"]
-  s.email       = ["santiago.bartesaghi@rootstrap.com"]
-  s.homepage    = "https://github.com/rootstrap/active_admin_chat"
-  s.summary     = "ActiveAdmin chat plugin"
+  s.authors     = ['Santiago Bartesaghi']
+  s.email       = ['santiago.bartesaghi@rootstrap.com']
+  s.homepage    = 'https://github.com/rootstrap/active_admin_chat'
+  s.summary     = 'ActiveAdmin chat plugin'
   s.description = s.summary
-  s.license     = "MIT"
+  s.license     = 'MIT'
 
-  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+  s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency "rails", "~> 5.2.1"
-  s.add_dependency "activeadmin", "~> 1.3.1"
+  s.add_dependency 'activeadmin', '~> 1.3.1'
+  s.add_dependency 'rails', '~> 5.2.1'
 
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rspec-rails", "~> 3.8"
-  s.add_development_dependency "capybara"
-  s.add_development_dependency "factory_bot_rails"
+  s.add_development_dependency 'capybara'
+  s.add_development_dependency 'factory_bot_rails'
+  s.add_development_dependency 'rspec-rails', '~> 3.8'
+  s.add_development_dependency 'rubocop', '~> 0.59.2'
+  s.add_development_dependency 'sqlite3'
 end

--- a/bin/rails
+++ b/bin/rails
@@ -10,16 +10,16 @@ APP_PATH = File.expand_path('../spec/dummy/config/application', __dir__)
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
-require "rails"
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-require "active_storage/engine"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_view/railtie"
-require "action_cable/engine"
-require "sprockets/railtie"
+require 'active_model/railtie'
+require 'active_job/railtie'
+require 'active_record/railtie'
+require 'active_storage/engine'
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+require 'action_view/railtie'
+require 'action_cable/engine'
+require 'sprockets/railtie'
 # require "rails/test_unit/railtie"
 require 'rails/engine/commands'

--- a/lib/active_admin_chat.rb
+++ b/lib/active_admin_chat.rb
@@ -1,7 +1,7 @@
-require "active_admin"
-require "active_admin_chat/engine"
-require "active_admin_chat/active_admin"
-require "active_admin_chat/active_admin/application"
+require 'active_admin'
+require 'active_admin_chat/engine'
+require 'active_admin_chat/active_admin'
+require 'active_admin_chat/active_admin/application'
 
 ::ActiveAdmin.send :include, ActiveAdminChat::ActiveAdmin
 ::ActiveAdmin::Application.send :include, ActiveAdminChat::ActiveAdmin::Application

--- a/lib/active_admin_chat/active_admin.rb
+++ b/lib/active_admin_chat/active_admin.rb
@@ -1,6 +1,6 @@
 module ActiveAdminChat
   module ActiveAdmin
-    def self.included base
+    def self.included(base)
       base.extend ClassMethods
     end
 

--- a/lib/active_admin_chat/active_admin/application.rb
+++ b/lib/active_admin_chat/active_admin/application.rb
@@ -6,7 +6,7 @@ module ActiveAdminChat
           # add chat defaults here
 
           # customize default chat
-          instance_eval &block
+          instance_eval(&block)
         end
       end
     end

--- a/lib/active_admin_chat/version.rb
+++ b/lib/active_admin_chat/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdminChat
-  VERSION = '0.1.0'
+  VERSION = '0.1.0'.freeze
 end

--- a/spec/active_admin_spec.rb
+++ b/spec/active_admin_spec.rb
@@ -1,12 +1,16 @@
-require "rails_helper"
+require 'rails_helper'
 
 describe ActiveAdmin do
-  context ".register_chat" do
+  context '.register_chat' do
     it "calls application's #register_page" do
       subject { ActiveAdmin }
-      expect(ActiveAdmin.application).to receive(:register_page).with("My Page", { namespace: "public" })
 
-      subject.register_chat "My Page", namespace: "public"
+      expect(ActiveAdmin.application).to receive(:register_page).with(
+        'My Page',
+        namespace: 'public'
+      )
+
+      subject.register_chat 'My Page', namespace: 'public'
     end
   end
 end

--- a/spec/dummy/app/admin/chat.rb
+++ b/spec/dummy/app/admin/chat.rb
@@ -1,5 +1,5 @@
-ActiveAdmin.register_chat "Chat" do
+ActiveAdmin.register_chat 'Chat' do
   content do
-    span "This is the chat"
+    span 'This is the chat'
   end
 end

--- a/spec/dummy/bin/yarn
+++ b/spec/dummy/bin/yarn
@@ -2,10 +2,10 @@
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   begin
-    exec "yarnpkg", *ARGV
+    exec 'yarnpkg', *ARGV
   rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    warn 'Yarn executable was not detected in the system.'
+    warn 'Download Yarn at https://yarnpkg.com/en/docs/install'
     exit 1
   end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,20 +1,20 @@
 require_relative 'boot'
 
-require "rails"
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-require "active_storage/engine"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_view/railtie"
-require "action_cable/engine"
-require "sprockets/railtie"
+require 'active_model/railtie'
+require 'active_job/railtie'
+require 'active_record/railtie'
+require 'active_storage/engine'
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+require 'action_view/railtie'
+require 'action_cable/engine'
+require 'sprockets/railtie'
 # require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)
-require "active_admin_chat"
+require 'active_admin_chat'
 
 module Dummy
   class Application < Rails::Application
@@ -27,4 +27,3 @@ module Dummy
     # the framework and any gems in your application.
   end
 end
-

--- a/spec/dummy/config/cable.yml
+++ b/spec/dummy/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
   channel_prefix: dummy_production

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   timeout: 5000
 
 development:

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -83,7 +83,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/spec/dummy/config/puma.rb
+++ b/spec/dummy/config/puma.rb
@@ -4,16 +4,16 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch('PORT', 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV', 'development')
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+# workers ENV.fetch("WEB_CONCURRENCY", 2)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/spec/features/chat_page_spec.rb
+++ b/spec/features/chat_page_spec.rb
@@ -1,9 +1,9 @@
-require "rails_helper"
+require 'rails_helper'
 
-feature "Visit the chat page" do
-  scenario "has the customized content" do
+feature 'Visit the chat page' do
+  scenario 'has the customized content' do
     visit admin_chat_path
 
-    expect(page).to have_content("This is the chat")
+    expect(page).to have_content('This is the chat')
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,14 +1,14 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../dummy/config/environment', __FILE__)
+require File.expand_path('dummy/config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Setup ActiveAdmin
-ActiveAdmin.application.load_paths = [File.expand_path('../dummy/app/admin', __FILE__)]
+ActiveAdmin.application.load_paths = [File.expand_path('dummy/app/admin', __dir__)]
 ActiveAdmin.unload!
 ActiveAdmin.load!
 Rails.application.reload_routes!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
- Adds rubocop gem.
- Takes the config file from https://github.com/rootstrap/rails_api_base/blob/master/.rubocop.yml and make some changes.
- Fixes the rubocop issues that currently exists in the repository.