### PR TITLE
Add required ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 language: ruby
 cache: bundler
 rvm:
-  - 2.2.10
+  - 2.2.2
   - 2.3.8
   - 2.4.5
   - 2.5.3
@@ -34,6 +34,6 @@ matrix:
   fast_finish: true
   exclude:
     - gemfile: gemfiles/5.2.gemfile
-      rvm: 2.2.10
+      rvm: 2.2.2
   allow_failures:
     - rvm: ruby-head

--- a/active_admin_chat.gemspec
+++ b/active_admin_chat.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
+  s.required_ruby_version = '>= 2.2.2'
+
   s.add_dependency 'activeadmin', '>= 1.0.0'
   s.add_dependency 'rails', '>= 5.0.0'
 


### PR DESCRIPTION
- Add required ruby version, the same version `Rails` 5.0.0 has
- Change Travis minimum `ruby` version to test 2.2.2, the minimum required for this gem